### PR TITLE
Use correct version of python + make install smoother

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ To build, create a new directory and run:
 To install (may require root), run from the same directory:
     % make install
 
+On UNIX systems, ensure that the install destination lib folder is added to
+your LD\_LIBRARY\_PATH, or add it to your /etc/ld.so.conf. A default install
+will place library files in /usr/local/lib, which is not searched by default
+on many Linux distributions.
+
+Examples:
+
+    % export LD_LIBRARY_PATH /usr/local/lib
+    or
+    % echo /usr/local/lib | sudo tee /etc/ld.so.conf
 
 WARNING
 =======

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Examples:
 
     % export LD_LIBRARY_PATH /usr/local/lib
     or
-    % echo /usr/local/lib | sudo tee /etc/ld.so.conf
+    % echo /usr/local/lib | sudo tee -a /etc/ld.so.conf
 
 WARNING
 =======

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -36,11 +36,11 @@ if(PYTHON_EXECUTABLE)
 else(PYTHON_EXECUTABLE)
 
     #use the built-in find script
-    find_package(PythonInterp)
+    find_package(PythonInterp 2.5)
 
     #and if that fails use the find program routine
     if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python python2.7 python2.6 python2.5)
+        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7 python2.6 python2.5)
         if(PYTHON_EXECUTABLE)
             set(PYTHONINTERP_FOUND TRUE)
         endif(PYTHON_EXECUTABLE)

--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -114,7 +114,7 @@ macro(GR_SWIG_MAKE name)
     endif()
 
     #append additional include directories
-    find_package(PythonLibs)
+    find_package(PythonLibs 2.5)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_PATH}) #deprecated name (now dirs)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
     list(APPEND GR_SWIG_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -51,6 +51,22 @@ GR_SWIG_MAKE(mixalot_swig mixalot_swig.i)
 ########################################################################
 GR_SWIG_INSTALL(TARGETS mixalot_swig DESTINATION ${GR_PYTHON_DIR}/mixalot)
 
+if(UNIX)
+    SET( swig_lib _mixalot_swig.lnk )
+    SET( swig_lib_target ${CMAKE_INSTALL_PREFIX}/${GR_PYTHON_DIR}/mixalot/_mixalot_swig.so )
+    ADD_CUSTOM_COMMAND( OUTPUT ${swig_lib}
+                        COMMAND ln -sf ${swig_lib_target} ${swig_lib}
+                        COMMENT "Generating system symlink for mixalot"
+    )
+    ADD_CUSTOM_TARGET( mixalot_swig_link
+                       ALL
+                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${swig_lib} )
+    install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${swig_lib}
+             DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/
+             RENAME _mixalot_swig.so )
+endif(UNIX)
+
+
 ########################################################################
 # Install swig .i files for development
 ########################################################################

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)
-find_package(PythonLibs)
+find_package(PythonLibs 2.5)
 if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
     return()
 endif()


### PR DESCRIPTION
Make cmake use only python2 on systems with both py2 and py3 installed

Make a symlink to _mixalog_swig.so in PREFIX/lib for easier LD_LIBRARY_PATH setup.