### PR TITLE
Exit program after the message is sent.

### DIFF
--- a/grc/pocsagtx.grc
+++ b/grc/pocsagtx.grc
@@ -37,7 +37,7 @@
     </param>
     <param>
       <key>run_options</key>
-      <value>prompt</value>
+      <value>run</value>
     </param>
     <param>
       <key>run</key>

--- a/grc/pocsagtx_hackrf.grc
+++ b/grc/pocsagtx_hackrf.grc
@@ -304,7 +304,7 @@
     </param>
     <param>
       <key>run_options</key>
-      <value>prompt</value>
+      <value>run</value>
     </param>
     <param>
       <key>run</key>


### PR DESCRIPTION
If not, the program will hang in the GNU radion companion.  Also, it is more
useful in a non-interactive setting if it do not require keyboard input.