### PR TITLE
Added ability to configure the function bit of a POCSAG transmission

### DIFF
--- a/grc/mixalot_pocencode.block.yml
+++ b/grc/mixalot_pocencode.block.yml
@@ -16,6 +16,9 @@ parameters:
 -   id: capcode
     label: Capcode
     dtype: int
+-   id: functionBit
+    label: Function Bit
+    dtype: int
 -   id: msg
     label: Message
     dtype: string
@@ -30,6 +33,6 @@ outputs:
 
 templates:
     imports: import gnuradio.mixalot as mixalot
-    make: mixalot.pocencode(${type}, ${baudrate}, ${capcode}, ${msg}, ${symrate})
+    make: mixalot.pocencode(${type}, ${baudrate}, ${capcode}, ${functionBit}, ${msg}, ${symrate})
 
 file_format: 1

--- a/include/gnuradio/mixalot/pocencode.h
+++ b/include/gnuradio/mixalot/pocencode.h
@@ -32,7 +32,7 @@ namespace gr {
        * class. mixalot::pocencode::make is the public interface for
        * creating new instances.
        */
-      static sptr make(int type=0, unsigned int baudrate = 1200, unsigned int capcode = 0, std::string message="", unsigned long symrate = 38400);
+      static sptr make(int type=0, unsigned int baudrate = 1200, unsigned int capcode = 0, unsigned int functionBit = 0, std::string message="", unsigned long symrate = 38400);
     };
 
   } // namespace mixalot

--- a/lib/pocencode_impl.h
+++ b/lib/pocencode_impl.h
@@ -26,13 +26,14 @@ namespace gr {
         int d_msgtype;                // message type
         unsigned int d_baudrate;            // baud rate to transmit at -- should be 512, 1200, or 2400 (although others will work!)
         unsigned int d_capcode;             // capcode (pager ID)
+        unsigned int d_functionBit;         // function bit to indicate the type of message
         unsigned long d_symrate;            // output symbol rate (must be evenly divisible by the baud rate)
         std::string d_message;              // message to send
 
         inline void queuebit(bool bit);
 
     public:
-      pocencode_impl(int msgtype, unsigned int baudrate, unsigned int capcode, std::string message, unsigned long symrate);
+      pocencode_impl(int msgtype, unsigned int baudrate, unsigned int capcode, unsigned int functionBit, std::string message, unsigned long symrate);
       ~pocencode_impl();
 
       // Where all the action really happens

--- a/python/mixalot/bindings/pocencode_python.cc
+++ b/python/mixalot/bindings/pocencode_python.cc
@@ -40,6 +40,7 @@ void bind_pocencode(py::module& m)
            py::arg("type") = 0,
            py::arg("baudrate") = 1200,
            py::arg("capcode") = 0,
+           py::arg("functionBit") = 0,
            py::arg("message") = "",
            py::arg("symrate") = 38400,
            D(pocencode,make)


### PR DESCRIPTION
I added the ability to change the function bit of a POCSAG Transmission.

Therefore I changed to Inputs of the gnuradio-companion block, python bindings and removed the default function bit of 0 for numeric transmissions and 3 for alphanumeric transmissions.

This should close Issue #19 