### PR TITLE
Remove register keyword

### DIFF
--- a/lib/golay.cc
+++ b/lib/golay.cc
@@ -141,7 +141,7 @@ long get_syndrome(long pattern)
 
 
 unsigned long calcgolay(unsigned long data) {
-   register int i;
+   int i;
    long temp;
 
    /*


### PR DESCRIPTION
Later versions of C no longer support the register keyword. This causes the following error when building:
```
/Users/xyz/Projects/gr-mixalot/lib/golay.cc:144:4: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
  144 |    register int i;
      |    ^~~~~~~~
1 error generated.
make[2]: *** [lib/CMakeFiles/gnuradio-mixalot.dir/golay.cc.o] Error 1
make[1]: *** [lib/CMakeFiles/gnuradio-mixalot.dir/all] Error 2
make: *** [all] Error 2
```